### PR TITLE
Potential fix for code scanning alert no. 4: Replacement of a substring with itself

### DIFF
--- a/components/common/MapView.tsx
+++ b/components/common/MapView.tsx
@@ -917,7 +917,7 @@ export default function CustomMapView({ color = "#A259FF", mode = 'moto', nearby
               <Text style={{ fontWeight: 'bold', fontSize: 15, color: accentColor, marginBottom: 2 }}>Navigation</Text>
               <Text style={{ fontSize: 14, color: colorScheme === 'dark' ? '#f3f4f6' : '#444', marginBottom: 2 }}>
                 {formatDistance(routeInfo.legs[0].distance.text)}
-                {'  '}|  {routeInfo.legs[0].duration.text.replace('hours', 'h').replace('hour', 'h').replace('mins', 'min').replace('min', 'min')}
+                {'  '}|  {routeInfo.legs[0].duration.text.replace('hours', 'h').replace('hour', 'h').replace('mins', 'min')}
               </Text>
             </View>
             <TouchableOpacity onPress={() => { setRouteMode('idle'); setRoutePolyline([]); setRouteInfo(null); setRoutePoints({}); setCurrentStepIndex(0); Speech.stop(); }} style={{ marginLeft: 8, backgroundColor: accentColor, borderRadius: 10, padding: 7, alignSelf: 'flex-start' }}>


### PR DESCRIPTION
Potential fix for [https://github.com/SDN33/EYESAPP/security/code-scanning/4](https://github.com/SDN33/EYESAPP/security/code-scanning/4)

To fix the issue, we need to remove the redundant `.replace('min', 'min')` operation from the chain of `replace` calls on line 920. This will ensure that the code only performs meaningful replacements, improving clarity and efficiency without altering the intended functionality.

The fix involves editing the string manipulation logic on line 920 to exclude the redundant replacement. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
