### PR TITLE
Potential fix for code scanning alert no. 5: Replacement of a substring with itself

### DIFF
--- a/utils/formatDistance.ts
+++ b/utils/formatDistance.ts
@@ -4,7 +4,7 @@
 export function formatDistance(text: string): string {
   if (!text) return '';
   // Si déjà en km, juste remplacer le séparateur
-  if (text.includes('km')) return text.replace('.', ',').replace('km', 'km');
+  if (text.includes('km')) return text.replace('.', ',');
   // Si en miles, convertir
   const match = text.match(/([\d.,]+)\s?mi/);
   if (match) {


### PR DESCRIPTION
Potential fix for [https://github.com/SDN33/EYESAPP/security/code-scanning/5](https://github.com/SDN33/EYESAPP/security/code-scanning/5)

To fix the issue, we should remove the redundant `.replace('km', 'km')` operation. Since the function's purpose is to format distances, the replacement of `'km'` with itself serves no purpose and can be safely omitted. This change will simplify the code without altering its functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
