### PR TITLE
Potential fix for code scanning alert no. 3: Replacement of a substring with itself

### DIFF
--- a/components/common/MapView.tsx
+++ b/components/common/MapView.tsx
@@ -822,7 +822,7 @@ export default function CustomMapView({ color = "#A259FF", mode = 'moto', nearby
                   Arrivée : {routeInfo.legs[0].end_address}
                 </Text>
                 <Text style={{ fontSize: 14, color: colorScheme === 'dark' ? '#d1d5db' : '#666', marginBottom: 16 }}>
-                  Durée : {routeInfo.legs[0].duration.text.replace('hours', 'h').replace('hour', 'h').replace('mins', 'min').replace('min', 'min')} | Distance : {formatDistance(routeInfo.legs[0].distance.text)}
+                  Durée : {routeInfo.legs[0].duration.text.replace('hours', 'h').replace('hour', 'h').replace('mins', 'min')} | Distance : {formatDistance(routeInfo.legs[0].distance.text)}
                 </Text>
                 {/* Options d'itinéraire */}
                 <Text style={{ fontWeight: 'bold', color: accentColor, fontSize: 15, marginBottom: 12 }}>Options d'itinéraire</Text>


### PR DESCRIPTION
Potential fix for [https://github.com/SDN33/EYESAPP/security/code-scanning/3](https://github.com/SDN33/EYESAPP/security/code-scanning/3)

To fix the issue, we should remove the redundant `.replace('min', 'min')` operation from the chain of `.replace()` calls on line 825. This will eliminate the unnecessary operation while preserving the intended functionality of normalizing time-related strings. The rest of the replacements in the chain should remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
